### PR TITLE
add chip select/enable for decoding SPI transaction on logic analyzer

### DIFF
--- a/lab/lab07/lab07_mcu/src/lab7.c
+++ b/lab/lab07/lab07_mcu/src/lab7.c
@@ -74,6 +74,11 @@ int main(void) {
   digitalWrite(PA9, 0);
   digitalWrite(PA10, 0);
 
+  // Artificial chip select signal to allow 8-bit CE-based SPI decoding on the logic analyzers.
+  pinMode(PA11, GPIO_OUTPUT);
+  digitalWrite(PA11, 1);
+
+
   // hardware accelerated encryption
   encrypt(key, plaintext, cyphertext);
   checkAnswer(key, plaintext, cyphertext);
@@ -109,12 +114,16 @@ void encrypt(char * key, char * plaintext, char * cyphertext) {
 
   // Send plaintext
   for(i = 0; i < 16; i++) {
+    digitalWrite(PA11, 1); // Arificial CE high
     spiSendReceive(plaintext[i]);
+    digitalWrite(PA11, 0); // Arificial CE low
   }
 
   // Send the key
   for(i = 0; i < 16; i++) {
+    digitalWrite(PA11, 1); // Arificial CE high
     spiSendReceive(key[i]);
+    digitalWrite(PA11, 0); // Arificial CE low
   }
 
   while(SPI1->SR & SPI_SR_BSY); // Confirm all SPI transactions are completed
@@ -124,5 +133,8 @@ void encrypt(char * key, char * plaintext, char * cyphertext) {
   while(!digitalRead(PA6));
 
   for(i = 0; i < 16; i++) {
-    cyphertext[i] = spiSendReceive(0);  }
+    digitalWrite(PA11, 1); // Arificial CE high
+    cyphertext[i] = spiSendReceive(0);  
+    digitalWrite(PA11, 0); // Arificial CE low
+  }
 }


### PR DESCRIPTION
I'm not sure if decoding is something students were expected to use at all, or if maybe we were just supposed to figure it out on our own, but in case fighting the decoding features was not an intended pain-point of this lab, this revision makes things a little easier. Maybe there is an even better solution I'm missing.

PR updates MCU code to use PA11 as an artificial chip-enable signal such that CE-based SPI decoding can be used on the scope in 8-bit chunks (the 128 bit chunks of our data already exceeds the 32-bit max, and 8-bit was the next most straightforward implementation). This was super helpful for me as I used SPI extensively to read off intermediate values. Timeout decoding by comparison seemed not to work very well.
